### PR TITLE
Disable follow_symlinks

### DIFF
--- a/ctfs/DownUnderCTF/2023/web/static_file_server/app.py
+++ b/ctfs/DownUnderCTF/2023/web/static_file_server/app.py
@@ -15,6 +15,6 @@ app.add_routes([
     web.get('/', index),
 
     # this is handled by https://github.com/aio-libs/aiohttp/blob/v3.8.5/aiohttp/web_urldispatcher.py#L654-L690
-    web.static('/files', './files', follow_symlinks=True)
+    web.static('/files', './files')
 ])
 web.run_app(app)


### PR DESCRIPTION
I'm checking that this parameter wasn't set by mistake.
The parameter allows a symlink to point to somewhere _outside_ of the static directory. Symlinks that point within the directory will work without enabling this parameter (it's badly named). Therefore enabling this option could make it easy to misconfigure an environment and introduce security issues.

If you're absolutely sure you need this parameter, then please ensure your server is upgraded to aiohttp 3.9.2 immediately (security advisory will be published about this tomorrow).